### PR TITLE
Allow setting ANTS config with plist/profile on MacOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,9 @@ You can also edit it using your favorite text editor.
 
 Do not modify the default configuration file as it might be overwritten when updating ANTS.
 
+On Mac OS, you can also configure ANTS with a preference list (plist) or configuration profile.
+Please note that configurations set in this manner will override any other configuration, including ``ants.cfg``.
+
 ---------------
 Run other roles
 ---------------

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -15,7 +15,7 @@ try:
     from antslib import macos_prefs
     use_macos_prefs = True
 except ImportError:
-    pass
+    use_macos_prefs = False
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -11,6 +11,8 @@ import pwd
 import grp
 import re
 
+from antslib import prefs
+
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -56,7 +58,10 @@ def read_config(config_section, config_file='ants.cfg'):
         print 'Ignoring system configuraiton'
         config.read([default_config])
 
-    return dict(config.items(config_section))
+    config_dict = dict(config.items(config_section))
+    prefs_dict = prefs.read_prefs(config_section)
+
+    return prefs.merge_prefs(config_dict, prefs_dict)
 
 
 def get_values(cfg, section_name):

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -10,10 +10,10 @@ import os
 import pwd
 import grp
 import re
-from sys import platform
 
 try:
-    from antslib import prefs
+    from antslib import macos_prefs
+    use_macos_prefs = True
 except ImportError:
     pass
 
@@ -64,9 +64,9 @@ def read_config(config_section, config_file='ants.cfg'):
 
     config_dict = dict(config.items(config_section))
 
-    if platform == 'darwin':
-        macos_dict = prefs.read_prefs(config_section)
-        config_dict = prefs.merge_dicts(config_dict, macos_dict)
+    if use_macos_prefs:
+        macos_dict = macos_prefs.read_prefs(config_section)
+        config_dict = macos_prefs.merge_dicts(config_dict, macos_dict)
 
     return config_dict
 

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -10,8 +10,12 @@ import os
 import pwd
 import grp
 import re
+from sys import platform
 
-from antslib import prefs
+try:
+    from antslib import prefs
+except ImportError:
+    pass
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -59,9 +63,12 @@ def read_config(config_section, config_file='ants.cfg'):
         config.read([default_config])
 
     config_dict = dict(config.items(config_section))
-    prefs_dict = prefs.read_prefs(config_section)
 
-    return prefs.merge_prefs(config_dict, prefs_dict)
+    if platform == 'darwin':
+        macos_dict = prefs.read_prefs(config_section)
+        config_dict = prefs.merge_dicts(config_dict, macos_dict)
+
+    return config_dict
 
 
 def get_values(cfg, section_name):

--- a/antslib/macos_prefs.py
+++ b/antslib/macos_prefs.py
@@ -1,7 +1,7 @@
-"""prefs
+"""macos_prefs
 ====================
 
-Handle parsing of configuration preference options.
+Handle parsing of macOS configuration preference options.
 
 Allows macOS configuration preferences to override
 config file options using a plist or configuration

--- a/antslib/prefs.py
+++ b/antslib/prefs.py
@@ -1,0 +1,76 @@
+"""prefs
+====================
+
+Handle parsing of configuration preference options.
+
+Allows macOS configuration preferences to override
+config file options using a plist or configuration
+profile for the set BUNDLE_ID.
+
+Preferences can be defined several places. Precedence is:
+    - MCX/configuration profile
+    - /var/root/Library/Preferences/[BUNDLE_ID].plist
+    - /Library/Preferences/[BUNDLE_ID].plist
+    - .GlobalPreferences defined at various levels (ByHost, user, system)
+"""
+
+
+# PyLint cannot properly find names inside Cocoa libraries, so issues bogus
+# No name 'CFPreferencesCopyAppValue' in module 'Foundation' warnings.
+# Disable them.
+# pylint: disable=E0611
+from Foundation import CFPreferencesCopyAppValue
+from PyObjCTools import Conversion
+# pylint: enable=E0611
+
+
+BUNDLE_ID = 'com.antsframework.ants'
+
+
+#####################################################
+# prefs functions
+#####################################################
+
+
+def convert_prefs_dict(prefs_dict):
+    """Convert Obj-C preference dictionary to Python dictionary.
+
+    Also converts every object in dictionary to a string.
+    """
+    python_dict = Conversion.pythonCollectionFromPropertyList(prefs_dict)
+    for k in python_dict.keys():
+        python_dict[k] = str(python_dict[k])
+    return python_dict
+
+
+def merge_prefs(config_dict, prefs_dict):
+    """Merge config and prefs dictionaries.
+
+    Overwrites values in config dict if also found in prefs dict.
+    """
+    for item in config_dict.keys():
+        if item in prefs_dict.keys():
+            config_dict[item] = prefs_dict[item]
+    return config_dict
+
+
+def read_prefs(prefs_section):
+    """Read indicated preferences section and return a dict.
+
+    Uses CFPreferencesCopyAppValue.
+    Preferences can be defined several places. Precedence is:
+        - MCX/configuration profile
+        - /var/root/Library/Preferences/[BUNDLE_ID].plist
+        - /Library/Preferences/[BUNDLE_ID].plist
+        - .GlobalPreferences defined at various levels (ByHost, user, system)
+    """
+    pref_dict = CFPreferencesCopyAppValue(prefs_section, BUNDLE_ID)
+    if pref_dict is None:
+        pref_dict = {}
+    else:
+        pref_dict = convert_prefs_dict(pref_dict)
+    return pref_dict
+
+
+if __name__ == '__main__':
+    pass

--- a/antslib/prefs.py
+++ b/antslib/prefs.py
@@ -20,11 +20,10 @@ Preferences can be defined several places. Precedence is:
 # Disable them.
 # pylint: disable=E0611
 from Foundation import CFPreferencesCopyAppValue
-from PyObjCTools import Conversion
 # pylint: enable=E0611
 
 
-BUNDLE_ID = 'com.antsframework.ants'
+BUNDLE_ID = 'com.github.ants-framework'
 
 
 #####################################################
@@ -32,25 +31,22 @@ BUNDLE_ID = 'com.antsframework.ants'
 #####################################################
 
 
-def convert_prefs_dict(prefs_dict):
-    """Convert Obj-C preference dictionary to Python dictionary.
-
-    Also converts every object in dictionary to a string.
-    """
-    python_dict = Conversion.pythonCollectionFromPropertyList(prefs_dict)
-    for k in python_dict.keys():
-        python_dict[k] = str(python_dict[k])
+def convert_dict(nsdict):
+    """Generates Python dict of strings from Obj-C NSDict."""
+    python_dict = {}
+    for k in nsdict.keys():
+        python_dict[str(k)] = str(nsdict[k])
     return python_dict
 
 
-def merge_prefs(config_dict, prefs_dict):
-    """Merge config and prefs dictionaries.
+def merge_dicts(config_dict, macos_dict):
+    """Merge config and MacOS prefs dictionaries.
 
     Overwrites values in config dict if also found in prefs dict.
     """
     for item in config_dict.keys():
-        if item in prefs_dict.keys():
-            config_dict[item] = prefs_dict[item]
+        if item in macos_dict.keys():
+            config_dict[item] = macos_dict[item]
     return config_dict
 
 
@@ -64,12 +60,12 @@ def read_prefs(prefs_section):
         - /Library/Preferences/[BUNDLE_ID].plist
         - .GlobalPreferences defined at various levels (ByHost, user, system)
     """
-    pref_dict = CFPreferencesCopyAppValue(prefs_section, BUNDLE_ID)
-    if pref_dict is None:
-        pref_dict = {}
+    macos_dict = CFPreferencesCopyAppValue(prefs_section, BUNDLE_ID)
+    if macos_dict is None:
+        macos_dict = {}
     else:
-        pref_dict = convert_prefs_dict(pref_dict)
-    return pref_dict
+        macos_dict = convert_dict(macos_dict)
+    return macos_dict
 
 
 if __name__ == '__main__':

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -7,6 +7,7 @@ PACKAGE_VERSION=1.3.6
 PAYLOAD=\
 		ants_client_virtualenv \
 		pack-script-preinstall \
+		pack-script-postinstall \
 		pack-pathd \
 		pack-Library-LaunchDaemons-ch.unibas.its.cs.ants.plist \
 		pack-Library-LaunchDaemons-ch.unibas.its.cs.ants.run-now.plist

--- a/macos/postinstall
+++ b/macos/postinstall
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#  ANTS pkg postinstall script
+#
+#  Creates symlinks to Apple PyObjC frameworks in ANTS
+#
+#
+#  Created by Jacob F. Grant
+#
+#  Created: 01/03/18
+#  Updated: 01/03/18
+#
+
+
+# Symlink objc library
+ln -s /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/PyObjC/objc /Library/ANTS-Framework/lib/python2.7/site-packages
+
+# Symlink Foundation library
+ln -s /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/PyObjC/Foundation /Library/ANTS-Framework/lib/python2.7/site-packages
+
+# Symlink CoreFoundation library
+ln -s /System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/PyObjC/CoreFoundation /Library/ANTS-Framework/lib/python2.7/site-packages


### PR DESCRIPTION
On MacOS, ANTS configuration can now be set using plist files in the standard locations (`~/Library/Preferences/` and `/Library/Preferences/`). They can also be set using a configuration profile (.mobileconfig file) targeting the `com.github.ants-framework` payload. This allows ANTS configurations to be pushed out using Apple MDM, munki, and other tools.

Minimal changes have been made to `configer.py` to allow for clarity and separation between general and OS-specific code—most of the new code can be found in `macos_prefs.py`.

The README has been updated with info on the new features.

A postinstall script as also been included (and added to The Luggage Makefile) to create symlinks to the PyObjC frameworks required by `macos_prefs.py`. No other changes to the package (including the version) have been made.

An example `com.github.ants-framework.plist` using the default values can be found below:

```<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>main</key>
        <dict>
            <key>wait_interval</key>
            <integer>900</integer>
            <key>inventory_script</key>
            <string>inventory_default</string>
            <key>destination</key>
            <string>~root/.ants_playbook</string>
            <key>ssh_key</key>
            <string>/etc/ants/id_ants</string>
            <key>ssh_stricthostkeychecking</key>
            <false/>
            <key>git_repository</key>
            <string>https://github.com/ANTS-Framework/playbook.git</string>
            <key>log_dir</key>
            <string>/var/log/ants</string>
            <key>branch</key>
            <string>master</string>
            <key>ansible_pull_exe</key>
            <string></string>
            <key>ansible_playbook</key>
            <string>main.yml</string>
        </dict>
        <key>ad</key>
        <dict>
            <key>ldap_user</key>
            <string>ldap\changeme</string>
            <key>ldap_pw</key>
            <string>changeme</string>
            <key>ldap_host</key>
            <string>LDAP.PRETENDCORP.COM</string>
            <key>ldap_ou_computers</key>
            <string>DC=ldap,DC=pretendcorp,DC=com</string>
            <key>ldap_ou_groups</key>
            <string>OU=ants,OU=Groups,DC=ldap,DC=pretendcorp,DC=com</string>
            <key>cache_file</key>
            <string>/etc/ants/inventory_cache.json</string>
            <key>group_prefix</key>
            <string>ants-</string>
            <key>common_group</key>
            <string>ants-common</string>
            <key>common_ad_connected</key>
            <string>common-ad-connected</string>
        </dict>
    </dict>
</plist>
  