### PR TITLE
Allow static inventory files.

### DIFF
--- a/bin/ants
+++ b/bin/ants
@@ -8,7 +8,7 @@ Run ansible-pull with a set of defined parameters
 and log the content of these runs.
 """
 
-__version__ = '1.5'
+__version__ = '1.5.1rc1'
 
 __author__ = "Balz Aschwanden"
 __email__ = "balz.aschwanden@unibas.ch"
@@ -100,18 +100,24 @@ def run_ansible(args):
         ansible_pull_exe = find_file('ansible-pull')
     if not ansible_pull_exe:
         sys.exit("Could not find executable ansible-pull. Aborting.")
+    if not os.access(ansible_pull_exe, os.X_OK):
+        sys.exit("File is not executable at %s. Aborting." % ansible_pull_exe)
     logger.console_logger.debug("Using %s" % ansible_pull_exe)
 
-    for f in [ansible_pull_exe, args.inventory]:
-        if not os.path.isfile(f):
-            sys.exit("Could not find file at %s. Aborting." % f)
-        if not os.access(f, os.X_OK):
-            sys.exit("File is not executable at %s. Aborting." % f)
+    inventory = args.inventory
+    if not os.path.isfile(inventory):
+        sys.exit("Could not find file at %s. Aborting." % inventory)
+
+    if not os.access(inventory, os.X_OK):
+        logger.console_logger.debug(
+            "Inventory file at %s is not executable." % inventory)
+        logger.console_logger.debug(
+            "Using static inventory file at %s." % inventory)
 
     cmd = [ansible_pull_exe,
            '--clean',
            '-f',
-           '-i', args.inventory,
+           '-i', inventory,
            '-d', args.destination,
            '-U', args.git_repo,
            '-C', args.branch,


### PR DESCRIPTION
Ansible-pull does allow for static inventory files as well as
inventory scripts. It makes sens to have the same behaviour in
ANTS. This commit removes the executable check from the
inventory file, allowing for any kind of file to be passed
to ANTS as inventory.