### PR TITLE
Logstash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ Reporting
 You can log the run results into your Logstash instance. Just add the following entries to the config file ``/etc/ants``.
 ``ansible_callback_whitelist = logstash`` and add a new section called ``[callback_plugins]``. This section should contain the ``LOGSTASH_SERVER`` and the ``LOGSTASH_PORT``. The defaults of the Logstash callback plugin are applied if you do not set these settings.
 
-You can add other callback plugins to ``ansible_callback_whitelist`` if you desire. The same is true from ``[callback_plugins]``. Just add environment variables to that sub section. 
+You can add other callback plugins to ``ansible_callback_whitelist`` if you desire. The same is true to ``[callback_plugins]``. Just add environment variables to that sub section. 
 
 Please note that the casing of the environment variables is essential for the callback plugins to work. The casing can be found using ``ansible-doc -t callback logstash $name_of_plugin``.
 

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ This entry on the other hand will look for your inventory file in ``/etc/ants``:
     inventory_script = /etc/ants/myinventory
 
 ---------------------
-Reporting
+Callback plugins and reporting
 ---------------------
 You can log the run results into your Logstash instance. Just add the following entries to the config file ``/etc/ants``.
 ``ansible_callback_whitelist = logstash`` and add a new section called ``[callback_plugins]``. This section should contain the ``LOGSTASH_SERVER`` and the ``LOGSTASH_PORT``. The defaults of the Logstash callback plugin are applied if you do not set these settings.

--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,16 @@ This entry on the other hand will look for your inventory file in ``/etc/ants``:
     [main]
     inventory_script = /etc/ants/myinventory
 
+---------------------
+Reporting
+---------------------
+You can log the run results into your Logstash instance. Just add the following entries to the config file ``/etc/ants``.
+``ansible_callback_whitelist = logstash`` and add a new section called ``[callback_plugins]``. This section should contain the ``LOGSTASH_SERVER`` and the ``LOGSTASH_PORT``. The defaults of the Logstash callback plugin are applied if you do not set these settings.
+
+You can add other callback plugins to ``ansible_callback_whitelist`` if you desire. The same is true from ``[callback_plugins]``. Just add environment variables to that sub section. 
+
+Please note that the casing of the environment variables is essential for the callback plugins to work. The casing can be found using ``ansible-doc -t callback logstash $name_of_plugin``.
+
 -------
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ Callback plugins and reporting
 You can log the run results into your Logstash instance. Just add the following entries to the config file ``/etc/ants``.
 ``ansible_callback_whitelist = logstash`` and add a new section called ``[callback_plugins]``. This section should contain the ``LOGSTASH_SERVER`` and the ``LOGSTASH_PORT``. The defaults of the Logstash callback plugin are applied if you do not set these settings.
 
-You can add other callback plugins to ``ansible_callback_whitelist`` if you desire. The same is true to ``[callback_plugins]``. Just add environment variables to that sub section. 
+You can add other callback plugins to ``ansible_callback_whitelist`` if you desire. The same is true for ``[callback_plugins]``. Just add environment variables to that sub section. 
 
 Please note that the casing of the environment variables is essential for the callback plugins to work. The casing can be found using ``ansible-doc -t callback logstash $name_of_plugin``.
 

--- a/antslib/argparser.py
+++ b/antslib/argparser.py
@@ -60,7 +60,7 @@ class ShowConfigAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if not configer.is_root():
             sys.exit('Script must be run as root')
-        cfg_sections = ['main', 'ad']
+        cfg_sections = ['main', 'ad', 'logstash']
         for section in cfg_sections:
             sys.stdout.write('[%s]\n' % (section))
             c = configer.read_config(section)

--- a/antslib/argparser.py
+++ b/antslib/argparser.py
@@ -60,7 +60,7 @@ class ShowConfigAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if not configer.is_root():
             sys.exit('Script must be run as root')
-        cfg_sections = ['main', 'ad', 'logstash']
+        cfg_sections = ['main', 'ad', 'callback_plugins']
         for section in cfg_sections:
             sys.stdout.write('[%s]\n' % (section))
             c = configer.read_config(section)

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -87,11 +87,12 @@ def get_config():
     """
     cfg_main = get_values(read_config('main'), 'main')
     cfg_ad = None
-    cfg_logstash = None
+    cfg_callback_plugins = None
     if cfg_main['inventory_script'] == 'inventory_ad':
         cfg_ad = get_values(read_config('ad'), 'ad')
-    if 'logstash' in cfg_main['ansible_callback_whitelist']:
-        cfg_logstash = get_values(read_config('logstash'), 'logstash')
+    if cfg_main['ansible_callback_whitelist']:
+        cfg_callback_plugins = get_values(read_config('callback_plugins'),
+                                          'callback_plugins')
 
     config = ConfigParser.ConfigParser()
     config.add_section('main')
@@ -101,15 +102,16 @@ def get_config():
         config.add_section('ad')
         for key, value in cfg_ad.iteritems():
             config.set('ad', key, value)
-    if cfg_logstash:
-        config.add_section('logstash')
+    if cfg_callback_plugins:
+        config.add_section('callback_plugins')
         for key, value in cfg_ad.iteritems():
-            config.set('logstash', key, value)
+            config.set('callback_plugins', key, value)
     return config
 
 
 def write_config(config, config_file='ants.cfg'):
-    """Writing ConfigParser object to local configuration. Existing files will be overwritten."""
+    """Writing ConfigParser object to local configuration.
+    Existing files will be overwritten."""
     config_path = '/etc/ants/'
     system_config = os.path.join(config_path, config_file)
     if not os.path.isdir(config_path):

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -7,7 +7,6 @@ Handle parsing of configuraiton file options.
 
 import ConfigParser
 import os
-import pwd
 import re
 
 try:
@@ -88,8 +87,11 @@ def get_config():
     """
     cfg_main = get_values(read_config('main'), 'main')
     cfg_ad = None
+    cfg_logstash = None
     if cfg_main['inventory_script'] == 'inventory_ad':
         cfg_ad = get_values(read_config('ad'), 'ad')
+    if 'logstash' in cfg_main['ansible_callback_whitelist']:
+        cfg_logstash = get_values(read_config('logstash'), 'logstash')
 
     config = ConfigParser.ConfigParser()
     config.add_section('main')
@@ -99,6 +101,10 @@ def get_config():
         config.add_section('ad')
         for key, value in cfg_ad.iteritems():
             config.set('ad', key, value)
+    if cfg_logstash:
+        config.add_section('logstash')
+        for key, value in cfg_ad.iteritems():
+            config.set('logstash', key, value)
     return config
 
 

--- a/antslib/etc/ants.cfg
+++ b/antslib/etc/ants.cfg
@@ -4,6 +4,7 @@ branch = master
 ssh_key = /etc/ants/id_ants
 destination = ~root/.ants_playbook
 inventory_script = inventory_default
+ansible_callback_whitelist = logstash
 wait_interval = 900
 ansible_playbook = main.yml
 log_dir = /var/log/ants
@@ -22,3 +23,7 @@ cache_file = /etc/ants/inventory_cache.json
 group_prefix = ants-
 common_group = ants-common
 common_ad_connected = ants-ad-connected
+
+[logstash]
+logstash_server = localhost
+logstash_port = 5000

--- a/antslib/etc/ants.cfg
+++ b/antslib/etc/ants.cfg
@@ -4,7 +4,7 @@ branch = master
 ssh_key = /etc/ants/id_ants
 destination = ~root/.ants_playbook
 inventory_script = inventory_default
-ansible_callback_whitelist = logstash
+ansible_callback_whitelist = 
 wait_interval = 900
 ansible_playbook = main.yml
 log_dir = /var/log/ants
@@ -24,6 +24,4 @@ group_prefix = ants-
 common_group = ants-common
 common_ad_connected = ants-ad-connected
 
-[logstash]
-logstash_server = localhost
-logstash_port = 5000
+[callback_plugins]

--- a/bin/ants
+++ b/bin/ants
@@ -156,6 +156,11 @@ def run_ansible(args):
     if args.skip_tags:
         cmd.append('--skip-tags')
         cmd.append(args.skip_tags)
+    if configer.read_config('logstash'):
+        cfg_logstash = configer.read_config('logstash')
+        os.environ['ANSIBLE_CALLBACK_WHITELIST'] = CFG['ansible_callback_whitelist']
+        os.environ['LOGSTASH_SERVER'] = cfg_logstash['logstash_server']
+        os.environ['LOGSTASH_PORT'] = cfg_logstash['logstash_port']
 
     proc = subprocess.Popen(cmd, bufsize=1, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)

--- a/bin/ants
+++ b/bin/ants
@@ -156,11 +156,13 @@ def run_ansible(args):
     if args.skip_tags:
         cmd.append('--skip-tags')
         cmd.append(args.skip_tags)
-    if configer.read_config('logstash'):
-        cfg_logstash = configer.read_config('logstash')
-        os.environ['ANSIBLE_CALLBACK_WHITELIST'] = CFG['ansible_callback_whitelist']
-        os.environ['LOGSTASH_SERVER'] = cfg_logstash['logstash_server']
-        os.environ['LOGSTASH_PORT'] = cfg_logstash['logstash_port']
+
+    if CFG['ansible_callback_whitelist']:
+        os.environ['ANSIBLE_CALLBACK_WHITELIST'] += ', %s' %\
+            CFG['ansible_callback_whitelist']
+        cfg_callback_plugins = configer.read_config('callback_plugins')
+        for key, value in cfg_callback_plugins:
+            os.environ[key] = value
 
     proc = subprocess.Popen(cmd, bufsize=1, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)

--- a/bin/ants
+++ b/bin/ants
@@ -158,10 +158,9 @@ def run_ansible(args):
         cmd.append(args.skip_tags)
 
     if CFG['ansible_callback_whitelist']:
-        os.environ['ANSIBLE_CALLBACK_WHITELIST'] += ', %s' %\
-            CFG['ansible_callback_whitelist']
+        os.environ['ANSIBLE_CALLBACK_WHITELIST'] = ', %s' % CFG['ansible_callback_whitelist']
         cfg_callback_plugins = configer.read_config('callback_plugins')
-        for key, value in cfg_callback_plugins:
+        for key, value in cfg_callback_plugins.iteritems():
             os.environ[key] = value
 
     proc = subprocess.Popen(cmd, bufsize=1, stdout=subprocess.PIPE,

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
     install_requires=[
         'ansible==2.6.1',
         'ldap3==2.5',
+        'logstash==0.1.dev0',
     ],
     package_data={
         'antslib': ['etc/ants.cfg'],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'ansible==2.6.1',
         'ldap3==2.5',
-        'logstash==0.1.dev0',
+        'python-logstash==0.4.6',
     ],
     package_data={
         'antslib': ['etc/ants.cfg'],


### PR DESCRIPTION
This PR adds the option to log the ansible output to logstash.

The feature can be enabled by adding 'logstash' to the '[main]' variable 'ansible_callback_whitelist'. This will then require 'logstash_server' and 'logstash_port' in a new '[logstash]' subsection of the config file.

This PR also adds a new module dependency to the ants-client: logstash

I have tested this PR on Centos. Can someone test it on macOS?

Cheers,
Jan