### PR TITLE
Using futurize to update python 3 incompatible parts

### DIFF
--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -57,8 +57,8 @@ def read_config(config_section, config_file="ants.cfg"):
     config.optionxform = str
     try:
         config.read([default_config, system_config])
-    except configparser.MissingSectionHeaderError as xxx_todo_changeme:
-        configparser.ParsingError = xxx_todo_changeme
+    except configparser.MissingSectionHeaderError as missing_section_error:
+        configparser.ParsingError = missing_section_error
         print("Error while reading configuration from %s." % system_config)
         print("Ignoring system configuraiton")
         config.read([default_config])

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -3,9 +3,14 @@
 
 Handle parsing of configuraiton file options.
 """
+from __future__ import print_function
 
 
-import ConfigParser
+from future import standard_library
+
+standard_library.install_aliases()
+from builtins import input
+import configparser
 import os
 import re
 
@@ -30,7 +35,7 @@ def create_dir(dir_name):
     """Create directory"""
     uid = os.getuid()
     gid = os.getgid()
-    os.mkdir(dir_name, 0755)
+    os.mkdir(dir_name, 0o755)
     os.chown(dir_name, uid, gid)
 
 
@@ -48,13 +53,14 @@ def read_config(config_section, config_file="ants.cfg"):
     if not os.path.isfile(default_config):
         raise OSError("Default config file not found at %s" % default_config)
 
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.optionxform = str
     try:
         config.read([default_config, system_config])
-    except ConfigParser.MissingSectionHeaderError, ConfigParser.ParsingError:
-        print "Error while reading configuration from %s." % system_config
-        print "Ignoring system configuraiton"
+    except configparser.MissingSectionHeaderError as xxx_todo_changeme:
+        configparser.ParsingError = xxx_todo_changeme
+        print("Error while reading configuration from %s." % system_config)
+        print("Ignoring system configuraiton")
         config.read([default_config])
 
     config_dict = dict(config.items(config_section))
@@ -77,11 +83,11 @@ def read_config(config_section, config_file="ants.cfg"):
 def get_values(cfg, section_name):
     """Take and return a dict of values and prompt the user for a reply."""
     msg = "Configuration for section: %s" % section_name
-    print "%s" % re.sub(r"[a-zA-Z :]", "#", msg)
-    print "%s" % msg
-    print "%s" % re.sub(r"[a-zA-Z :]", "#", msg)
-    for key, value in cfg.iteritems():
-        cfg[key] = raw_input("%s [Example: %s]:" % (key, value)) or value
+    print("%s" % re.sub(r"[a-zA-Z :]", "#", msg))
+    print("%s" % msg)
+    print("%s" % re.sub(r"[a-zA-Z :]", "#", msg))
+    for key, value in cfg.items():
+        cfg[key] = input("%s [Example: %s]:" % (key, value)) or value
     return cfg
 
 
@@ -104,17 +110,17 @@ def get_config():
             read_config("callback_plugins"), "callback_plugins"
         )
 
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.add_section("main")
-    for key, value in cfg_main.iteritems():
+    for key, value in cfg_main.items():
         config.set("main", key, value)
     if cfg_ad:
         config.add_section("ad")
-        for key, value in cfg_ad.iteritems():
+        for key, value in cfg_ad.items():
             config.set("ad", key, value)
     if cfg_callback_plugins:
         config.add_section("callback_plugins")
-        for key, value in cfg_ad.iteritems():
+        for key, value in cfg_ad.items():
             config.set("callback_plugins", key, value)
     return config
 

--- a/antslib/configer.py
+++ b/antslib/configer.py
@@ -53,7 +53,7 @@ def read_config(config_section, config_file="ants.cfg"):
     if not os.path.isfile(default_config):
         raise OSError("Default config file not found at %s" % default_config)
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(strict=False)
     config.optionxform = str
     try:
         config.read([default_config, system_config])

--- a/antslib/inventory/inventory_ad
+++ b/antslib/inventory/inventory_ad
@@ -16,6 +16,7 @@ It always returns the common group for common tasks. It also returns the group
 common-ad-bound if the result comes from an online query rather than from the
 cache.
 """
+from __future__ import print_function
 
 __author__ = "Jan Welker"
 __email__ = "jan.welker@unibas.ch"
@@ -194,7 +195,7 @@ def main():
         output[cfg["common_ad_connected"]] = [fqdn]
 
         # Printing output in Ansible JSON syntax
-        print format_output(output)
+        print(format_output(output))
 
     # We are not bound to AD we are offline
     else:
@@ -203,12 +204,12 @@ def main():
         cached_output = read_cache(cache_file)
         if cached_output:
             # Printing cached
-            print cached_output
+            print(cached_output)
         else:
             # Printing default group
             output = dict()
             output[cfg["common_group"]] = [fqdn]
-            print format_output(output)
+            print(format_output(output))
 
 
 if __name__ == "__main__":

--- a/antslib/inventory/inventory_default
+++ b/antslib/inventory/inventory_default
@@ -14,6 +14,7 @@ These values can be used to assign roles in local.yml but
 using a dynamic inventory script like inventory_ad.py
 is the prefered way of running ants.
 """
+from __future__ import print_function
 
 __author__ = "Balz Aschwanden"
 __email__ = "balz.aschwanden@unibas.ch"
@@ -31,7 +32,7 @@ def main():
     output = dict()
     fqdn = helper.get_hostname()
     output["ants-common"] = [fqdn]
-    print helper.format_output(output)
+    print(helper.format_output(output))
 
 
 if __name__ == "__main__":

--- a/antslib/macos_prefs.py
+++ b/antslib/macos_prefs.py
@@ -19,6 +19,7 @@ Preferences can be defined several places. Precedence is:
 # No name 'CFPreferencesCopyAppValue' in module 'Foundation' warnings.
 # Disable them.
 # pylint: disable=E0611
+from builtins import str
 from Foundation import CFPreferencesCopyAppValue
 
 # pylint: enable=E0611
@@ -35,7 +36,7 @@ BUNDLE_ID = "com.github.ants-framework"
 def convert_dict(nsdict):
     """Generates Python dict of strings from Obj-C NSDict."""
     python_dict = {}
-    for k in nsdict.keys():
+    for k in list(nsdict.keys()):
         python_dict[str(k)] = str(nsdict[k])
     return python_dict
 
@@ -45,8 +46,8 @@ def merge_dicts(config_dict, macos_dict):
 
     Overwrites values in config dict if also found in prefs dict.
     """
-    for item in config_dict.keys():
-        if item in macos_dict.keys():
+    for item in list(config_dict.keys()):
+        if item in list(macos_dict.keys()):
             config_dict[item] = macos_dict[item]
     return config_dict
 

--- a/antslib/plugins/callback/ants_logstash.py
+++ b/antslib/plugins/callback/ants_logstash.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from builtins import str
 import copy
 import json
 import logging
@@ -163,14 +164,14 @@ class CallbackModule(CallbackBase):
         """
         new_list = []
         for e in data_list:
-            new_list.append(unicode(str(e), "utf-8"))
+            new_list.append(str(e))
         self._display.vv(
             'Logstash Callback:\tForced unicode for list "%s": %s' % (key, new_list)
         )
         return new_list
 
     def recurse_results(self, results_dict, data, task_name):
-        for key, value in results_dict.iteritems():
+        for key, value in results_dict.items():
             if type(value) is dict:
                 data = self.recurse_results(value, data, task_name)
             else:
@@ -187,7 +188,7 @@ class CallbackModule(CallbackBase):
             "Logstash Callback:\tPrinting dataset for ansible_type '%s'"
             % data["ansible_type"]
         )
-        for key, value in data.iteritems():
+        for key, value in data.items():
             self._display.vv("Logstash Callback:\t\t%s: %s" % (key, value))
 
     def v2_playbook_on_start(self, playbook):
@@ -203,7 +204,7 @@ class CallbackModule(CallbackBase):
         end_time = datetime.utcnow()
         runtime = end_time - self.start_time
         summarize_stat = {}
-        for host in stats.processed.keys():
+        for host in list(stats.processed.keys()):
             summarize_stat[host] = stats.summarize(host)
 
         if self.errors == 0:

--- a/bin/ants
+++ b/bin/ants
@@ -64,7 +64,8 @@ def parse_proc(proc):
     recap_line = None
     get_recap = False
     start_run_time = datetime.datetime.now()
-    for line in iter(proc.stdout.readline, ""):
+    for line in iter(proc.stdout.readline, b""):
+        line = line.decode("utf-8")
         logger.write_log(line, task_line)
         if line.startswith("TASK"):
             task_line = line

--- a/bin/ants
+++ b/bin/ants
@@ -183,7 +183,7 @@ def run_ansible(args):
         )
         os.environ["ANSIBLE_CALLBACK_WHITELIST"] = args.ansible_callback_whitelist
         cfg_callback_plugins = configer.read_config("callback_plugins")
-        for key, value in cfg_callback_plugins.iteritems():
+        for key, value in cfg_callback_plugins.items():
             logger.console_logger.debug("Add env variable: %s: %s" % (key, value))
             os.environ[key] = value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible==2.9.0
 ldap3==2.6.1
 python-logstash==0.4.6
 configparser==4.0.2
+future==0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible==2.9.0
 ldap3==2.6.1
 python-logstash==0.4.6
+configparser==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setuptools.setup(
         "antslib.inventory": ["inventory_default", "inventory_ad"],
         "antslib.plugins": ["callback/ants_logstash.py"],
     },
-    python_requires=">=2.7, <3",
+    python_requires=">=2.7",
 )


### PR DESCRIPTION
Mostly print statements, the config parser and dictionary use are changed to allow the use of python 2 and 3.

The changes to the single commands were tested, but nevertheless this should be tested if it works as intended.