### PR TITLE
Add verbosity to status information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 build/
 dist/
+*venv*


### PR DESCRIPTION
The argument -s/--status does now have an optional verbose flag. The syntax is now ```ants (-s|--status) [v|verbose]``` and if v or verbose is specified more information about the last run is printed.